### PR TITLE
Navbar experiment

### DIFF
--- a/src/components/Directory.js
+++ b/src/components/Directory.js
@@ -10,6 +10,9 @@ const useStyles = makeStyles((theme) => ({
   directory: {
     display: 'flex',
     justifyContent: 'center',
+  },
+  container: {
+    position: 'relative',
   }
 }));
 
@@ -70,7 +73,7 @@ export default function Directory() {
   }
 
   return (
-    <>
+    <Container disableGutters maxWidth={false} className={classes.container}>
       <DirectoryNavBar>
         <Container maxWidth="xl" className={classes.directory}>
           <DirectoryGrid
@@ -78,7 +81,6 @@ export default function Directory() {
           />
         </Container>
       </DirectoryNavBar>
-
-    </>
+    </Container>
   );
 }

--- a/src/components/Directory.js
+++ b/src/components/Directory.js
@@ -74,7 +74,7 @@ export default function Directory() {
 
   return (
     <Container disableGutters maxWidth={false} className={classes.container}>
-      <DirectoryNavBar>
+      <DirectoryNavBar filtered={filters} handler={toggleFilter}>
         <Container maxWidth="xl" className={classes.directory}>
           <DirectoryGrid
             filtered={filters}

--- a/src/components/Directory.js
+++ b/src/components/Directory.js
@@ -3,12 +3,13 @@ import { makeStyles } from '@material-ui/core/styles';
 import { Container } from '@material-ui/core';
 import DirectoryGrid from './DirectoryGrid';
 import FilterMenu from './Menu';
+import DirectoryNavBar from './DirectoryNavBar';
 import { CATEGORIES, TAGS, COSTS, TYPES, STAGES } from '../constants/filters';
 
 const useStyles = makeStyles((theme) => ({
   directory: {
     display: 'flex',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
   }
 }));
 
@@ -69,14 +70,15 @@ export default function Directory() {
   }
 
   return (
-    <Container maxWidth="xl" className={classes.directory}>
-      <FilterMenu
-        filtered={filters}
-        handler={toggleFilter}
-      />
-      <DirectoryGrid
-        filtered={filters}
-      />
-    </Container>
+    <>
+      <DirectoryNavBar>
+        <Container maxWidth="xl" className={classes.directory}>
+          <DirectoryGrid
+            filtered={filters}
+          />
+        </Container>
+      </DirectoryNavBar>
+
+    </>
   );
 }

--- a/src/components/DirectoryGrid.js
+++ b/src/components/DirectoryGrid.js
@@ -7,7 +7,7 @@ import DirectoryCard from './DirectoryCard';
 
 const useStyles = makeStyles((theme) => ({
   cardGrid: {
-    width: '80%',
+    width: '100%',
     paddingTop: theme.spacing(8),
     paddingBottom: theme.spacing(8),
   }
@@ -49,7 +49,7 @@ export default function DirectoryGrid(props) {
 
         }).map((edge, index) => (
           <Fade in={true} timeout={1500}>
-            <Grid item key={index} xs={6} lg={4}>
+            <Grid item key={index} xs={12} sm={6} lg={4}>
               <DirectoryCard data={edge.node}/>
             </Grid>
           </Fade>

--- a/src/components/DirectoryNavBar.js
+++ b/src/components/DirectoryNavBar.js
@@ -1,0 +1,156 @@
+
+import React from 'react';
+import clsx from 'clsx';
+import { makeStyles, useTheme } from '@material-ui/core/styles';
+import Drawer from '@material-ui/core/Drawer';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import AppBar from '@material-ui/core/AppBar';
+import Toolbar from '@material-ui/core/Toolbar';
+import List from '@material-ui/core/List';
+import Typography from '@material-ui/core/Typography';
+import Divider from '@material-ui/core/Divider';
+import IconButton from '@material-ui/core/IconButton';
+import MenuIcon from '@material-ui/icons/Menu';
+import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
+import ChevronRightIcon from '@material-ui/icons/ChevronRight';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import InboxIcon from '@material-ui/icons/MoveToInbox';
+import MailIcon from '@material-ui/icons/Mail';
+
+const drawerWidth = 300;
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+  },
+  appBar: {
+    transition: theme.transitions.create(['margin', 'width'], {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen,
+    }),
+  },
+  appBarShift: {
+    width: `calc(100% - ${drawerWidth}px)`,
+    marginLeft: drawerWidth,
+    transition: theme.transitions.create(['margin', 'width'], {
+      easing: theme.transitions.easing.easeOut,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
+  },
+  menuButton: {
+    marginRight: theme.spacing(2),
+  },
+  hide: {
+    display: 'none',
+  },
+  drawer: {
+    width: drawerWidth,
+    flexShrink: 0,
+  },
+  drawerPaper: {
+    width: drawerWidth,
+  },
+  drawerHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    padding: theme.spacing(0, 1),
+    // necessary for content to be below app bar
+    ...theme.mixins.toolbar,
+    justifyContent: 'flex-end',
+  },
+  content: {
+    flexGrow: 1,
+    padding: theme.spacing(3),
+    transition: theme.transitions.create('margin', {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen,
+    }),
+  },
+  contentShift: {
+    transition: theme.transitions.create('margin', {
+      easing: theme.transitions.easing.easeOut,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
+    marginLeft: drawerWidth,
+  },
+}));
+
+export default function DirectoryNavBar({ children }) {
+  const classes = useStyles();
+  const [open, setOpen] = React.useState(false);
+
+  const handleDrawerOpen = () => {
+    setOpen(true);
+  };
+
+  const handleDrawerClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <AppBar
+        position="sticky"
+        className={clsx(classes.appBar, {
+          [classes.appBarShift]: open,
+        })}
+      >
+        <Toolbar>
+          <IconButton
+            color="inherit"
+            aria-label="open drawer"
+            onClick={handleDrawerOpen}
+            edge="start"
+            className={clsx(classes.menuButton, open && classes.hide)}
+          >
+            <MenuIcon />
+          </IconButton>
+          <Typography variant="h6" noWrap>
+            Resources
+          </Typography>
+        </Toolbar>
+      </AppBar>
+      <main
+        className={clsx(classes.content, {
+          [classes.contentShift]: open,
+        })}
+      >
+        {children}
+      </main>
+      <Drawer
+        className={classes.drawer}
+        variant="persistent"
+        anchor="left"
+        open={open}
+        classes={{
+          paper: classes.drawerPaper,
+        }}
+      >
+        <div className={classes.drawerHeader}>
+          <IconButton onClick={handleDrawerClose}/>
+        </div>
+        <Divider />
+        <List>
+          {['Inbox', 'Starred', 'Send email', 'Drafts'].map((text, index) => (
+            <ListItem button key={text}>
+              <ListItemIcon>{index % 2 === 0 ? <InboxIcon /> : <MailIcon />}</ListItemIcon>
+              <ListItemText primary={text} />
+            </ListItem>
+          ))}
+        </List>
+        <Divider />
+        <List>
+          {['All mail', 'Trash', 'Spam'].map((text, index) => (
+            <ListItem button key={text}>
+              <ListItemIcon>{index % 2 === 0 ? <InboxIcon /> : <MailIcon />}</ListItemIcon>
+              <ListItemText primary={text} />
+            </ListItem>
+          ))}
+        </List>
+      </Drawer>
+
+    </>
+  );
+}

--- a/src/components/DirectoryNavBar.js
+++ b/src/components/DirectoryNavBar.js
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import clsx from 'clsx';
-import { makeStyles, useTheme } from '@material-ui/core/styles';
+import { makeStyles, fade } from '@material-ui/core/styles';
 import Drawer from '@material-ui/core/Drawer';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import AppBar from '@material-ui/core/AppBar';
@@ -10,7 +10,6 @@ import List from '@material-ui/core/List';
 import Typography from '@material-ui/core/Typography';
 import Divider from '@material-ui/core/Divider';
 import IconButton from '@material-ui/core/IconButton';
-import MenuIcon from '@material-ui/icons/Menu';
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import ListItem from '@material-ui/core/ListItem';
@@ -18,6 +17,10 @@ import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import InboxIcon from '@material-ui/icons/MoveToInbox';
 import MailIcon from '@material-ui/icons/Mail';
+import { CATEGORIES } from '../constants/filters';
+import InputBase from '@material-ui/core/InputBase';
+import MenuIcon from '@material-ui/icons/Menu';
+import SearchIcon from '@material-ui/icons/Search';
 
 const drawerWidth = 360;
 
@@ -75,6 +78,45 @@ const useStyles = makeStyles((theme) => ({
     }),
     marginLeft: drawerWidth,
   },
+  search: {
+    position: 'relative',
+    borderRadius: theme.shape.borderRadius,
+    backgroundColor: fade(theme.palette.common.white, 0.15),
+    '&:hover': {
+      backgroundColor: fade(theme.palette.common.white, 0.25),
+    },
+    marginLeft: 0,
+    width: '100%',
+    [theme.breakpoints.up('sm')]: {
+      marginLeft: theme.spacing(1),
+      width: 'auto',
+    },
+  },
+  searchIcon: {
+    padding: theme.spacing(0, 2),
+    height: '100%',
+    position: 'absolute',
+    pointerEvents: 'none',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  inputRoot: {
+    color: 'inherit',
+  },
+  inputInput: {
+    padding: theme.spacing(1, 1, 1, 0),
+    // vertical padding + font size from searchIcon
+    paddingLeft: `calc(1em + ${theme.spacing(4)}px)`,
+    transition: theme.transitions.create('width'),
+    width: '100%',
+    [theme.breakpoints.up('sm')]: {
+      width: '20ch',
+      '&:focus': {
+        width: '30ch',
+      },
+    },
+  },
 }));
 
 export default function DirectoryNavBar({ children }) {
@@ -108,6 +150,19 @@ export default function DirectoryNavBar({ children }) {
           >
             <MenuIcon />
           </IconButton>
+          <div className={classes.search}>
+            <div className={classes.searchIcon}>
+              <SearchIcon />
+            </div>
+            <InputBase
+              placeholder="Search…"
+              classes={{
+                root: classes.inputRoot,
+                input: classes.inputInput,
+              }}
+              inputProps={{ 'aria-label': 'search' }}
+            />
+          </div>
         </Toolbar>
       </AppBar>
       <main
@@ -133,24 +188,17 @@ export default function DirectoryNavBar({ children }) {
           </IconButton>
         </div>
         <List>
-          {['Inbox', 'Starred', 'Send email', 'Drafts'].map((text, index) => (
-            <ListItem button key={text}>
-              <ListItemIcon>{index % 2 === 0 ? <InboxIcon /> : <MailIcon />}</ListItemIcon>
-              <ListItemText primary={text} />
-            </ListItem>
-          ))}
-        </List>
-        <Divider light/>
-        <List>
-          {['All mail', 'Trash', 'Spam'].map((text, index) => (
-            <ListItem button key={text}>
-              <ListItemIcon>{index % 2 === 0 ? <InboxIcon /> : <MailIcon />}</ListItemIcon>
-              <ListItemText primary={text} />
-            </ListItem>
-          ))}
+          {CATEGORIES.map((value, index) => {
+            const labelId = `checkbox-list-label-${index}`;
+
+            return (
+              <ListItem button key={value}>
+                <ListItemText id={labelId} primary={value} />
+              </ListItem>
+            )
+          })}
         </List>
       </Drawer>
-
     </>
   );
 }

--- a/src/components/DirectoryNavBar.js
+++ b/src/components/DirectoryNavBar.js
@@ -19,7 +19,7 @@ import ListItemText from '@material-ui/core/ListItemText';
 import InboxIcon from '@material-ui/icons/MoveToInbox';
 import MailIcon from '@material-ui/icons/Mail';
 
-const drawerWidth = 300;
+const drawerWidth = 360;
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -97,6 +97,7 @@ export default function DirectoryNavBar({ children }) {
           [classes.appBarShift]: open,
         })}
       >
+        <Divider light/>
         <Toolbar>
           <IconButton
             color="inherit"
@@ -107,9 +108,6 @@ export default function DirectoryNavBar({ children }) {
           >
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" noWrap>
-            Resources
-          </Typography>
         </Toolbar>
       </AppBar>
       <main
@@ -121,17 +119,19 @@ export default function DirectoryNavBar({ children }) {
       </main>
       <Drawer
         className={classes.drawer}
+        PaperProps={{ style: { position: 'absolute' } }}
         variant="persistent"
-        anchor="left"
         open={open}
         classes={{
           paper: classes.drawerPaper,
         }}
       >
+        <Divider light/>
         <div className={classes.drawerHeader}>
-          <IconButton onClick={handleDrawerClose}/>
+          <IconButton onClick={handleDrawerClose}>
+            <ChevronLeftIcon/>
+          </IconButton>
         </div>
-        <Divider />
         <List>
           {['Inbox', 'Starred', 'Send email', 'Drafts'].map((text, index) => (
             <ListItem button key={text}>
@@ -140,7 +140,7 @@ export default function DirectoryNavBar({ children }) {
             </ListItem>
           ))}
         </List>
-        <Divider />
+        <Divider light/>
         <List>
           {['All mail', 'Trash', 'Spam'].map((text, index) => (
             <ListItem button key={text}>

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -21,14 +21,6 @@ export default function Layout({ children }) {
 
   return (
     <>
-      <AppBar position="relative">
-        <Toolbar>
-          <MapIcon className={classes.icon} />
-          <Typography variant="h6" color="inherit" noWrap>
-            APM Map
-          </Typography>
-        </Toolbar>
-      </AppBar>
       <main>{children}</main>
       <footer className={classes.footer}>
         <Copyright />

--- a/src/theme.js
+++ b/src/theme.js
@@ -41,14 +41,9 @@ let theme = createMuiTheme({
   shape: {
     borderRadius: 8,
   },
-  props: {
-    MuiTab: {
-      disableRipple: true,
-    },
-  },
   mixins: {
     toolbar: {
-      minHeight: 48,
+      minHeight: 56,
     },
   },
 });
@@ -58,8 +53,9 @@ theme = {
   overrides: {
     MuiDrawer: {
       paper: {
-        backgroundColor: '#18202c',
+        backgroundColor: '#ffff',
       },
+      position: "relative",
     },
     MuiButton: {
       label: {
@@ -97,7 +93,7 @@ theme = {
     },
     MuiIconButton: {
       root: {
-        padding: theme.spacing(1),
+        padding: theme.spacing(2),
       },
     },
     MuiTooltip: {


### PR DESCRIPTION
**Background**
*What is this and why build it in the first place?*

We deployed version 1 of this and lives [here](https://michellema1208.github.io/apm-map/)! @michellema1208 pointed out that some valid bugs/improvements that could be made to the filter menu -- mobile optimization, removing/renaming some categories, etc. This PR was an experiment that reimagined what the menu would look like as a Material UI [Drawer](https://material-ui.com/components/drawers/#persistent-drawer) within an [App Bar](https://material-ui.com/components/app-bar/#app-bar) with an embedded search field and given a 👍 deploying this soon!

**Implementation Highlights**
*Quick rundown how this was made*

- Create a new `DirectoryNavBar` component (pending refactor and cleanup)
- Notable tweaks
     - made directory content a child component to this navbar and centered its content (to allow for smooth drawer transitions and resizing)
     - remove unused theme overrides to avoid confusing styling

**Related Notes**
*Documenting my thought process, open questions, concerns, etc.*

Per usual, we keep tabs on product/technical updates on our notion [page](https://www.notion.so/APM-Map-0bba74b752da4a5ea9353084a0161603) 🎉 

**Next Steps**
*Risks, assumptions, next steps*

minor UI tweaks per feedback on this, make filters actual change directory content, implement simple searching. **Until these next steps are completed, these changes will remain in development (not deployed)**
