### PR TITLE
update airtable filters to ignore empty records

### DIFF
--- a/src/apis/airtable.js
+++ b/src/apis/airtable.js
@@ -10,6 +10,7 @@ async function getAllDirectoryResources() {
   return resources
     .select({
       sort: [{ field: "relevance", direction: "desc" }],
+      filterByFormula: "NOT({image} = '')", // ignore records w/o image urls
     })
     .all();
 }
@@ -23,7 +24,11 @@ async function getDirectoryResourceByID(id) {
 const mentors = base.table("Mentors");
 
 async function getAllMentors() {
-  return mentors.select().all();
+  return mentors
+    .select({
+      filterByFormula: "NOT({image} = '')", // ignore records w/o image urls
+    })
+    .all();
 }
 
 async function getMentorByID(id) {


### PR DESCRIPTION
### Background
Previous builds were failing because fetching empty records from airtable caused an error during the Gatsby's `onCreateNode`. This fixes that by explicitly ignoring records without image url fields (the most problematic to have empty and a good proxy for an "ignorable record")

### Implementation Summary
- use the `filterByFormula` selection query param specified using the airtable SDK to ignore fields in both mentors + directory resources sheets